### PR TITLE
Fix PHP 8.5 __doRequest() signature incompatibility (#179)

### DIFF
--- a/src/ParallelSoapClient.php
+++ b/src/ParallelSoapClient.php
@@ -265,10 +265,11 @@ class ParallelSoapClient extends \SoapClient implements LoggerAwareInterface
      * @param string $action The SOAP action
      * @param int $version The SOAP version
      * @param bool $oneWay If one_way is set to 1, this method returns nothing. Use this where a response is not expected
+     * @param string|null $uriParserClass The URI parser class added by PHP 8.5; unused here, kept for signature compatibility
      *
      * @return string
      */
-    public function __doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false): ?string
+    public function __doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false, ?string $uriParserClass = null): ?string
     {
         $shouldGetResponse = ($this->soapMethod == static::GET_RESPONSE_CONST);
 


### PR DESCRIPTION
## Problem

On PHP 8.5, `SoapClient::__doRequest()` gained a new trailing optional parameter `?string $uriParserClass = null`. `ParallelSoapClient::__doRequest()` still used the pre-8.5 signature, so the class is fatal at load time on PHP 8.5 with a "Declaration ... must be compatible with ..." error.

Fixes #179.

## Fix

Add the `?string $uriParserClass = null` parameter to the override so it matches the parent. The parameter is unused — this only restores signature compatibility.

Because the parameter is optional and trailing, the override stays compatible with PHP 8.0–8.4 (adding optional parameters in a subclass is allowed by PHP).

## Testing

`php -l src/ParallelSoapClient.php` passes.
